### PR TITLE
Release 1.7.5 and scope SignPath policy to force-push protection

### DIFF
--- a/.signpath/policies/TrayToolbar/release-signing.yml
+++ b/.signpath/policies/TrayToolbar/release-signing.yml
@@ -5,11 +5,10 @@ github-policies:
     require_github_hosted: true
   build:
     disallow_reruns: true
+  # Release builds run on tag refs, and GitHub tag rulesets cannot enforce
+  # pull request rules, so this policy only requires the force-push protection
+  # that both the master branch ruleset and the release tag ruleset provide.
   branch_rulesets:
     - condition:
         rules:
           - block_force_pushes: true
-          - require_linear_history: false
-          - require_pull_request:
-              min_required_approvals: 0
-              require_review_thread_resolution: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.7.4] - 2026-07-22
+## [1.7.5] - 2026-07-22
 
-`v1.7.2` and `v1.7.3` were tagged but never published. The `v1.7.2` release build failed while loading the SignPath GitHub policy, and the `v1.7.3` build failed SignPath CI system validation because the repository had no GitHub rulesets. 1.7.4 carries the same changes plus both fixes.
+`v1.7.2`, `v1.7.3`, and `v1.7.4` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, and on no ruleset applying to the release tag ref. 1.7.5 carries the same changes plus all three fixes.
 
 ### Added
 
@@ -30,7 +30,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - Fixed `build.ps1`'s `dotnet msbuild` fallback so the local portable packaging parity script works on machines where standalone `msbuild.exe` is not on `PATH`.
 - Removed the unsupported `allow_bypass_actors` key from the SignPath GitHub policy, which the SignPath policy loader rejected and which failed the `v1.7.2` release signing step.
-- Relaxed the SignPath branch ruleset policy to require a pull request and review-thread resolution without a minimum approval count, so a GitHub ruleset on `master` can satisfy origin verification on a solo-maintained repository.
+- Reduced the SignPath branch ruleset policy to the force-push protection that both the `master` branch ruleset and the release tag ruleset can enforce, because release builds run on tag refs and GitHub tag rulesets cannot enforce pull request rules.
 
 ## [1.7.1] - 2026-04-22
 
@@ -89,7 +89,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.4...HEAD
-[1.7.4]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.4
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.5...HEAD
+[1.7.5]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.5
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.7.4
+## 1.7.5
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2 and 1.7.3: both tags were pushed but never published, because their release builds failed SignPath policy loading and CI system validation respectively. 1.7.4 is the first release of this work.
+- Note on 1.7.2, 1.7.3, and 1.7.4: those tags were pushed but never published, because their release builds failed SignPath policy loading and CI system validation while the signing policy and GitHub rulesets were being brought into agreement. 1.7.5 is the first release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.7.4</Version>
+    <Version>1.7.5</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.4.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.7.5.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Retry of the 1.7.2 / 1.7.3 / 1.7.4 release attempts, all of which failed in the SignPath signing step.

The v1.7.4 build failed CI system validation with `There are no rulesets applicable to the current branch 'v1.7.4'`. Release builds run on a tag ref, and the master ruleset only covers `refs/heads/master`. GitHub tag rulesets cannot enforce pull request rules, so the policy is reduced to the force-push protection that both the master branch ruleset and a new release tag ruleset can satisfy.

- Reduce the SignPath branch ruleset policy to `block_force_pushes`
- Bump to 1.7.5 in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md` to 1.7.5

A tag ruleset for `refs/tags/v*` with `deletion` and `non_fast_forward` rules is added alongside this change.
