### PR TITLE
Release 1.7.6 and widen the SignPath approval wait

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -166,6 +166,9 @@ jobs:
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ steps.upload-unsigned-arm64.outputs.artifact-id }}
           wait-for-completion: true
+          # The release signing policy requires manual approval in SignPath,
+          # so allow an hour instead of the ten minute default.
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: signpath/arm64
           skip-decompress: true
 
@@ -180,6 +183,9 @@ jobs:
           artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ steps.upload-unsigned-x64.outputs.artifact-id }}
           wait-for-completion: true
+          # The release signing policy requires manual approval in SignPath,
+          # so allow an hour instead of the ten minute default.
+          wait-for-completion-timeout-in-seconds: 3600
           output-artifact-directory: signpath/x64
           skip-decompress: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.7.5] - 2026-07-22
+## [1.7.6] - 2026-07-22
 
-`v1.7.2`, `v1.7.3`, and `v1.7.4` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, and on no ruleset applying to the release tag ref. 1.7.5 carries the same changes plus all three fixes.
+`v1.7.2` through `v1.7.5` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request itself. 1.7.6 carries the same changes plus those fixes.
 
 ### Added
 
@@ -31,6 +31,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 - Fixed `build.ps1`'s `dotnet msbuild` fallback so the local portable packaging parity script works on machines where standalone `msbuild.exe` is not on `PATH`.
 - Removed the unsupported `allow_bypass_actors` key from the SignPath GitHub policy, which the SignPath policy loader rejected and which failed the `v1.7.2` release signing step.
 - Reduced the SignPath branch ruleset policy to the force-push protection that both the `master` branch ruleset and the release tag ruleset can enforce, because release builds run on tag refs and GitHub tag rulesets cannot enforce pull request rules.
+- Raised the SignPath signing request wait timeout from the ten minute default to one hour, so release builds do not time out while the signing request waits for manual approval.
 
 ## [1.7.1] - 2026-04-22
 
@@ -89,7 +90,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.5...HEAD
-[1.7.5]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.5
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.6...HEAD
+[1.7.6]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.6
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.7.5
+## 1.7.6
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2, 1.7.3, and 1.7.4: those tags were pushed but never published, because their release builds failed SignPath policy loading and CI system validation while the signing policy and GitHub rulesets were being brought into agreement. 1.7.5 is the first release of this work.
+- Note on 1.7.2 through 1.7.5: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and approval timeout were being brought into agreement. 1.7.6 is the first release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.5.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.7.6.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Retry of the 1.7.2 through 1.7.5 release attempts.

The `v1.7.5` build cleared SignPath CI system validation for the first time — the tag ruleset fix worked — and then failed at `Invalid request to SignPath API`. The release signing policy requires manual approval in SignPath, and the signing action waits only ten minutes by default.

- Raise `wait-for-completion-timeout-in-seconds` to 3600 on both signing steps
- Bump to 1.7.6 in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md` to 1.7.6

The release run will pause at the signing step until the request is approved in the SignPath portal.
