### PR TITLE
Release 1.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.7.6] - 2026-07-22
+## [1.7.7] - 2026-07-22
 
-`v1.7.2` through `v1.7.5` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request itself. 1.7.6 carries the same changes plus those fixes.
+`v1.7.2` through `v1.7.6` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request submission. Branch builds sign normally throughout, so the remaining failure is specific to tag refs. 1.7.7 carries the same changes plus those fixes.
 
 ### Added
 
@@ -90,7 +90,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.6...HEAD
-[1.7.6]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.6
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.7...HEAD
+[1.7.7]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.7
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.7.6
+## 1.7.7
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2 through 1.7.5: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and approval timeout were being brought into agreement. 1.7.6 is the first release of this work.
+- Note on 1.7.2 through 1.7.6: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and approval timeout were being brought into agreement. 1.7.7 is the first release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.7.6</Version>
+    <Version>1.7.7</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.6.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.7.7.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Retry of the 1.7.2 through 1.7.6 release attempts.

Branch builds sign normally — the `master` push run 29939375548 signed both architectures at 16:47 — while the `v1.7.6` tag run submitted a minute later was rejected in five seconds with `Invalid request to SignPath API`. The failure is specific to tag refs, not to the SignPath project configuration.

`ACTIONS_STEP_DEBUG` is enabled on the repository, so this tag run should either publish the release or log the API response body behind the generic 400.

- Bump to 1.7.7 in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md` to 1.7.7

The release run pauses at the signing step until the request is approved in the SignPath portal.
