### PR TITLE
Release 1.7.8 and fix the release signing collisions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -13,6 +13,17 @@ permissions:
   actions: read
   contents: read
 
+# Runs that submit signing requests share one queue, because a master push and
+# the release tag push that follows it produce identically named artifacts and
+# SignPath rejects the second submission while the first is still in flight.
+# Pull request builds do not sign, so they queue per ref and stay parallel.
+concurrency:
+  group: >-
+    ${{ github.event_name == 'pull_request'
+        && format('portable-release-pr-{0}', github.ref)
+        || 'portable-release-signing' }}
+  cancel-in-progress: false
+
 jobs:
   build-test-package:
     name: Validate and package portable release
@@ -89,10 +100,14 @@ jobs:
           $isTagBuild = '${{ github.ref_type }}' -eq 'tag'
           $isPullRequest = '${{ github.event_name }}' -eq 'pull_request'
 
-          $signingPolicy = if ($isPullRequest) {
-            'test-signing'
+          if ($isPullRequest) {
+            Write-Host 'SignPath signing is skipped for pull request builds.'
+            'enabled=false' >> $env:GITHUB_OUTPUT
+            'signing_policy_slug=' >> $env:GITHUB_OUTPUT
+            exit 0
           }
-          elseif ($isTagBuild -and -not [string]::IsNullOrWhiteSpace($env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG)) {
+
+          $signingPolicy = if ($isTagBuild -and -not [string]::IsNullOrWhiteSpace($env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG)) {
             $env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG
           }
           elseif (-not [string]::IsNullOrWhiteSpace($env:SIGNPATH_CI_SIGNING_POLICY_SLUG)) {
@@ -198,9 +213,14 @@ jobs:
             -Arm64Asset '${{ steps.version.outputs.arm64_asset }}' `
             -X64Asset '${{ steps.version.outputs.x64_asset }}'
 
+      # These artifacts are named explicitly because upload-artifact derives the
+      # artifact name from the file name when archive is false, which collides
+      # with the unsigned artifacts uploaded for SignPath earlier in this run.
+      # The published release assets come from the paths below, not these names.
       - name: Upload arm64 portable zip
         uses: actions/upload-artifact@v7
         with:
+          name: release-${{ steps.version.outputs.arm64_asset }}
           path: ${{ steps.final-assets.outputs.arm64_path }}
           archive: false
           if-no-files-found: error
@@ -210,6 +230,7 @@ jobs:
       - name: Upload x64 portable zip
         uses: actions/upload-artifact@v7
         with:
+          name: release-${{ steps.version.outputs.x64_asset }}
           path: ${{ steps.final-assets.outputs.x64_path }}
           archive: false
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.7.7] - 2026-07-22
+## [1.7.8] - 2026-07-22
 
-`v1.7.2` through `v1.7.6` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request submission. Branch builds sign normally throughout, so the remaining failure is specific to tag refs. 1.7.7 carries the same changes plus those fixes.
+`v1.7.2` through `v1.7.7` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request submission returning `400 Bad Request` while a concurrent master push build held the same artifact name. 1.7.8 carries the same changes plus those fixes.
 
 ### Added
 
@@ -32,6 +32,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 - Removed the unsupported `allow_bypass_actors` key from the SignPath GitHub policy, which the SignPath policy loader rejected and which failed the `v1.7.2` release signing step.
 - Reduced the SignPath branch ruleset policy to the force-push protection that both the `master` branch ruleset and the release tag ruleset can enforce, because release builds run on tag refs and GitHub tag rulesets cannot enforce pull request rules.
 - Raised the SignPath signing request wait timeout from the ten minute default to one hour, so release builds do not time out while the signing request waits for manual approval.
+- Disabled SignPath signing on `pull_request` builds entirely, so pull request validation no longer submits test signing requests.
+- Serialized the builds that submit signing requests, so a release tag build no longer submits while the master push build for the same commit is still signing identically named artifacts.
+- Named the final portable release artifacts explicitly, so uploading them no longer conflicts with the unsigned artifacts uploaded for SignPath earlier in the same run.
 
 ## [1.7.1] - 2026-04-22
 
@@ -90,7 +93,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.7...HEAD
-[1.7.7]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.7
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.8...HEAD
+[1.7.8]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.8
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.7.7
+## 1.7.8
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2 through 1.7.6: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and approval timeout were being brought into agreement. 1.7.7 is the first release of this work.
+- Note on 1.7.2 through 1.7.7: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and build concurrency were being brought into agreement. 1.7.8 is the first release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.7.7</Version>
+    <Version>1.7.8</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.7.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.7.8.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Fixes the three problems that kept 1.7.2 through 1.7.7 from publishing.

**Pull request builds no longer sign.** They submitted `test-signing` requests that are not needed.

**Builds that sign are serialized.** Merging a release PR and pushing the tag seconds later started two Portable Release runs at once, both producing identically named artifacts. For `v1.7.6` the master push run signed arm64 at 16:47:39 while the tag run submitted at 16:47:57 and was rejected with `400 Bad Request` five seconds later. A `workflow_dispatch` run with nothing alongside it signed both architectures cleanly.

**Final artifacts are named explicitly.** `upload-artifact` derives the artifact name from the file name when `archive: false`, so the final upload collided with the unsigned artifact uploaded for SignPath earlier in the same run. That dispatch run reached `(409) Conflict: an artifact with this name already exists on the workflow run` after signing succeeded. `overwrite: true` does not help, because the conflict is with a different artifact of the same name in the same run. The published release assets come from workspace paths, so the artifact names are cosmetic.

Also bumps to 1.7.8 and rolls `CHANGELOG.md` and `docs/release-notes.md`.

The tag will be pushed only after this PR's master build finishes, so the two do not overlap.
