### PR TITLE
Archive the final portable release artifacts

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -213,16 +213,16 @@ jobs:
             -Arm64Asset '${{ steps.version.outputs.arm64_asset }}' `
             -X64Asset '${{ steps.version.outputs.x64_asset }}'
 
-      # These artifacts are named explicitly because upload-artifact derives the
-      # artifact name from the file name when archive is false, which collides
-      # with the unsigned artifacts uploaded for SignPath earlier in this run.
-      # The published release assets come from the paths below, not these names.
+      # These artifacts are archived and named explicitly. With archive false,
+      # upload-artifact names the artifact after the file, which collides with
+      # the unsigned artifacts uploaded for SignPath earlier in this run, and
+      # the explicit name is not applied. The published release assets come from
+      # the paths below, so these artifact names are only used on the run page.
       - name: Upload arm64 portable zip
         uses: actions/upload-artifact@v7
         with:
-          name: release-${{ steps.version.outputs.arm64_asset }}
+          name: release-win-arm64-portable-${{ steps.version.outputs.version }}
           path: ${{ steps.final-assets.outputs.arm64_path }}
-          archive: false
           if-no-files-found: error
           retention-days: 14
           overwrite: true
@@ -230,9 +230,8 @@ jobs:
       - name: Upload x64 portable zip
         uses: actions/upload-artifact@v7
         with:
-          name: release-${{ steps.version.outputs.x64_asset }}
+          name: release-win-x64-portable-${{ steps.version.outputs.version }}
           path: ${{ steps.final-assets.outputs.x64_path }}
-          archive: false
           if-no-files-found: error
           retention-days: 14
           overwrite: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 - Raised the SignPath signing request wait timeout from the ten minute default to one hour, so release builds do not time out while the signing request waits for manual approval.
 - Disabled SignPath signing on `pull_request` builds entirely, so pull request validation no longer submits test signing requests.
 - Serialized the builds that submit signing requests, so a release tag build no longer submits while the master push build for the same commit is still signing identically named artifacts.
-- Named the final portable release artifacts explicitly, so uploading them no longer conflicts with the unsigned artifacts uploaded for SignPath earlier in the same run.
+- Archived and explicitly named the final portable release artifacts, so uploading them no longer conflicts with the unsigned artifacts uploaded for SignPath earlier in the same run. With `archive: false`, `actions/upload-artifact` names the artifact after the file and ignores the explicit name, which made both uploads claim the same artifact name.
 
 ## [1.7.1] - 2026-04-22
 


### PR DESCRIPTION
The 1.7.8 master push run signed both architectures successfully and then failed at `Upload arm64 portable zip` with `(409) Conflict: an artifact with this name already exists on the workflow run`.

The explicit artifact name added earlier did not take effect. The debug log shows `ListArtifacts` for `release-TrayToolbar-win-arm64-portable-1.7.8.zip` returning `"artifacts": []`, followed immediately by `CreateArtifact` failing with 409 — because with `archive: false`, `actions/upload-artifact` names the artifact after the file, which is identical to the unsigned artifact already uploaded for SignPath in the same run.

Dropping `archive: false` on the two final uploads lets the explicit `name` input apply.

Signing is confirmed working end to end. From that same run:

```
Normalized SignPath artifact name from 'signpath/arm64/...1.7.8.zip.zip' to '...1.7.8.zip'
Resolved arm64 asset path: signpath/arm64/TrayToolbar-win-arm64-portable-1.7.8.zip
Resolved x64 asset path:   signpath/x64/TrayToolbar-win-x64-portable-1.7.8.zip
```

No version bump: 1.7.8 was never published, so the tag will be pushed against this commit once the master build passes.

The published release assets come from workspace paths, so their file names are unchanged and `UpdateLogic` asset-name validation is unaffected. Only the run page artifact names change.
