### PR TITLE
Release 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.7.8] - 2026-07-22
+## [1.8.0] - 2026-07-22
 
-`v1.7.2` through `v1.7.7` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, and on the signing request submission returning `400 Bad Request` while a concurrent master push build held the same artifact name. 1.7.8 carries the same changes plus those fixes.
+`v1.7.2` through `v1.7.8` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, on the signing request submission returning `400 Bad Request` while a concurrent master push build held the same artifact name, and on the signed artifact upload colliding with the unsigned artifact uploaded for SignPath. 1.8.0 is the first published release of this work.
 
 ### Added
 
@@ -93,7 +93,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.7.8...HEAD
-[1.7.8]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.7.8
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.8.0
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.7.8
+## 1.8.0
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2 through 1.7.7: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, and signing request submission while the signing policy, GitHub rulesets, and build concurrency were being brought into agreement. 1.7.8 is the first release of this work.
+- Note on 1.7.2 through 1.7.8: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, signing request submission, and signed artifact upload while the signing policy, GitHub rulesets, build concurrency, and artifact naming were being brought into agreement. 1.8.0 is the first published release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.7.8</Version>
+    <Version>1.8.0</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.7.8.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.8.0.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Final end-to-end release of the SignPath code signing work.

The master push build for the previous commit passed the full pipeline for the first time: both architectures signed, the signed zips resolved on the runner, and both final artifact uploads succeeded. Only the tag-gated publish step remains unexercised, which this release covers.

- Bump to 1.8.0 in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md` to 1.8.0

Published as a prerelease, matching the current workflow behavior.

The tag will be pushed only after this PR's master build completes, so the two signing runs do not overlap.
