### PR TITLE
Publish releases from a branch run instead of a tag push

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,11 +1,17 @@
 name: Portable Release
 
 on:
+  # Releases are published from a branch run rather than a tag push, because
+  # SignPath rejects signing requests submitted from a tag ref with 400 Bad
+  # Request while the same artifact signs normally from a branch ref.
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish a GitHub Release for the version in TrayToolbar.csproj'
+        type: boolean
+        default: false
   push:
     branches: [ "master" ]
-    tags:
-      - "v*.*.*"
   pull_request:
     branches: [ "master" ]
 
@@ -97,7 +103,7 @@ jobs:
           SIGNPATH_CI_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_CI_SIGNING_POLICY_SLUG }}
           SIGNPATH_RELEASE_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_RELEASE_SIGNING_POLICY_SLUG }}
         run: |
-          $isTagBuild = '${{ github.ref_type }}' -eq 'tag'
+          $isReleasePublish = '${{ github.event_name == 'workflow_dispatch' && inputs.publish }}' -eq 'true'
           $isPullRequest = '${{ github.event_name }}' -eq 'pull_request'
 
           if ($isPullRequest) {
@@ -107,7 +113,7 @@ jobs:
             exit 0
           }
 
-          $signingPolicy = if ($isTagBuild -and -not [string]::IsNullOrWhiteSpace($env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG)) {
+          $signingPolicy = if ($isReleasePublish -and -not [string]::IsNullOrWhiteSpace($env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG)) {
             $env:SIGNPATH_RELEASE_SIGNING_POLICY_SLUG
           }
           elseif (-not [string]::IsNullOrWhiteSpace($env:SIGNPATH_CI_SIGNING_POLICY_SLUG)) {
@@ -135,8 +141,8 @@ jobs:
           )
 
           if ($missing.Count -gt 0) {
-            if ($isTagBuild) {
-              throw "SignPath signing is required for tag builds. Missing configuration: $($missing -join ', ')."
+            if ($isReleasePublish) {
+              throw "SignPath signing is required for release builds. Missing configuration: $($missing -join ', ')."
             }
 
             Write-Warning "SignPath signing is disabled because the following GitHub secrets/variables are missing: $($missing -join ', ')."
@@ -237,9 +243,10 @@ jobs:
           overwrite: true
 
       - name: Publish GitHub Release assets
-        if: github.ref_type == 'tag'
+        if: github.event_name == 'workflow_dispatch' && inputs.publish
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: v${{ steps.version.outputs.version }}
           body_path: ${{ github.workspace }}/docs/release-notes.md
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 - Reduced the SignPath branch ruleset policy to the force-push protection that both the `master` branch ruleset and the release tag ruleset can enforce, because release builds run on tag refs and GitHub tag rulesets cannot enforce pull request rules.
 - Raised the SignPath signing request wait timeout from the ten minute default to one hour, so release builds do not time out while the signing request waits for manual approval.
 - Disabled SignPath signing on `pull_request` builds entirely, so pull request validation no longer submits test signing requests.
+- Moved release publication from a tag push to a `workflow_dispatch` run with the `publish` input, which creates tag `v<Version>` from the project version. SignPath rejects signing requests submitted from a tag ref with `400 Bad Request`, while the same artifact and signing policy succeed from a branch ref.
 - Serialized the builds that submit signing requests, so a release tag build no longer submits while the master push build for the same commit is still signing identically named artifacts.
 - Archived and explicitly named the final portable release artifacts, so uploading them no longer conflicts with the unsigned artifacts uploaded for SignPath earlier in the same run. With `archive: false`, `actions/upload-artifact` names the artifact after the file and ignores the explicit name, which made both uploads claim the same artifact name.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Expected portable release outputs from `build.ps1` and CI:
 ## Release and versioning discipline
 
 - The version source of truth is `<Version>` in `src/TrayToolbar/TrayToolbar.csproj`.
-- Release tags should use `v<Version>` and match the project version exactly.
+- Release tags should use `v<Version>` and match the project version exactly. The release workflow creates the tag from the project version, so it is not pushed by hand.
 - `CHANGELOG.md` is the canonical release history.
 - `docs/release-notes.md` remains the supplemental narrative release summary.
 - The GitHub Actions workflow in `.github/workflows/dotnet-desktop.yml` is the canonical producer of release artifacts.
@@ -64,8 +64,10 @@ Current workflow behavior:
 
 - `push` on `master`: restore, test, format verification, build portable zip artifacts, and SignPath-sign them when the repository SignPath configuration is present
 - `pull_request` on `master`: the same validation and packaging flow, but signing is intentionally skipped so signing credentials are not exposed to untrusted pull-request code
-- `workflow_dispatch`: same validation and packaging flow for branch or tag dry runs, with signing when SignPath is configured and the run is not a pull request
-- `push` of `v*.*.*` tags: same packaging flow plus GitHub Release asset publication from the SignPath-signed assets; tag builds require SignPath configuration
+- `workflow_dispatch` with `publish` unset: same validation and packaging flow as a branch dry run, with signing when SignPath is configured
+- `workflow_dispatch` with `publish` set: same packaging flow plus GitHub Release asset publication from the SignPath-signed assets, creating tag `v<Version>` from the project version; release runs require SignPath configuration
+
+Releases are published from a branch run rather than a tag push. SignPath rejects signing requests submitted from a tag ref with `400 Bad Request`, while the same artifact and signing policy succeed from a branch ref, so the release path never builds from a tag.
 
 If a release is intended to be update-visible, publish it as a stable GitHub Release with the expected portable asset names.
 `UpdateLogic` validates those names and the GitHub Releases URL surface.


### PR DESCRIPTION
SignPath rejects signing requests submitted from a tag ref. Four runs isolate the cause to the ref type, with the event held constant both ways:

| Trigger | Ref | Signing |
| - | - | - |
| `push` | `refs/heads/master` | signs |
| `workflow_dispatch` | `refs/heads/master` | signs |
| `push` | `refs/tags/v1.8.0` | `400 Bad Request` after 5s |
| `workflow_dispatch` | `refs/tags/v1.8.0` | `400 Bad Request` after 5s |

The connector logs `Received response: 400 Bad Request` and nothing else, even with `ACTIONS_STEP_DEBUG` enabled, so the reason is only visible on the SignPath side. Same artifact configuration, same signing policy, same API token in all four.

Since branch runs sign reliably, the release path moves off tag builds entirely:

- Drop the `v*.*.*` tag push trigger, so no more doomed tag runs
- Add a `publish` boolean input to `workflow_dispatch`
- Give the publish step `tag_name: v${{ steps.version.outputs.version }}`, so the release run creates the tag from the project version
- Replace the `isTagBuild` signing conditions with `isReleasePublish`, keeping the rule that a release run requires SignPath configuration

`CONTRIBUTING.md` and `CHANGELOG.md` are updated to match, including why the tag path is avoided.

`v1.8.0` already points at the current master commit, so publishing from master reuses that existing tag rather than creating a new one.
