### PR TITLE
Release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
-## [1.8.0] - 2026-07-22
+## [1.8.1] - 2026-07-22
 
-`v1.7.2` through `v1.7.8` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, on the signing request submission returning `400 Bad Request` while a concurrent master push build held the same artifact name, and on the signed artifact upload colliding with the unsigned artifact uploaded for SignPath. 1.8.0 is the first published release of this work.
+`v1.7.2` through `v1.8.0` were tagged but never published. Their release builds failed in turn on SignPath policy loading, on the repository having no GitHub rulesets, on no ruleset applying to the release tag ref, on the signed artifact upload colliding with the unsigned artifact uploaded for SignPath, and finally on SignPath rejecting every signing request submitted from a tag ref with `400 Bad Request`. 1.8.1 is the first published release of this work, and the first published by a branch run.
 
 ### Added
 
@@ -34,7 +34,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 - Raised the SignPath signing request wait timeout from the ten minute default to one hour, so release builds do not time out while the signing request waits for manual approval.
 - Disabled SignPath signing on `pull_request` builds entirely, so pull request validation no longer submits test signing requests.
 - Moved release publication from a tag push to a `workflow_dispatch` run with the `publish` input, which creates tag `v<Version>` from the project version. SignPath rejects signing requests submitted from a tag ref with `400 Bad Request`, while the same artifact and signing policy succeed from a branch ref.
-- Serialized the builds that submit signing requests, so a release tag build no longer submits while the master push build for the same commit is still signing identically named artifacts.
+- Serialized the builds that submit signing requests, so two runs for the same commit no longer sign identically named artifacts at the same time.
 - Archived and explicitly named the final portable release artifacts, so uploading them no longer conflicts with the unsigned artifacts uploaded for SignPath earlier in the same run. With `archive: false`, `actions/upload-artifact` names the artifact after the file and ignores the explicit name, which made both uploads claim the same artifact name.
 
 ## [1.7.1] - 2026-04-22
@@ -94,7 +94,7 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.0...HEAD
-[1.8.0]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.8.0
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.1...HEAD
+[1.8.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.8.1
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.8.0
+## 1.8.1
 
 ## Highlights
 
@@ -20,7 +20,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - More reliable local packaging parity. `build.ps1` now works on machines that rely on the .NET SDK's `dotnet msbuild` fallback instead of a standalone `msbuild.exe` on `PATH`.
 - Also included a benchmark project plus contributor docs and templates to support future maintenance.
 - Unsigned PR or local portable builds are no longer considered valid automatic-update artifacts unless they are signed with the allowed TrayToolbar publisher identity.
-- Note on 1.7.2 through 1.7.8: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, signing request submission, and signed artifact upload while the signing policy, GitHub rulesets, build concurrency, and artifact naming were being brought into agreement. 1.8.0 is the first published release of this work.
+- Note on 1.7.2 through 1.8.0: those tags were pushed but never published, because their release builds failed SignPath policy loading, CI system validation, signing request submission, and signed artifact upload. SignPath rejects signing requests submitted from a tag ref, so releases are now published from a branch run that creates the tag. 1.8.1 is the first published release of this work.
 - **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
 
 ## Features

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.0.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.8.1.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Final end-to-end release, published from a branch run.

`v1.8.0` was tagged before the release path moved off tag builds, so it points at a commit that predates the workflow change. Publishing a release for it would attach assets built from a different commit than the tag references. 1.8.1 lets the release run create the tag from the project version, so the tag and the assets match exactly.

- Bump to 1.8.1 in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md` to 1.8.1

Also corrects two changelog claims that later evidence disproved. The `400 Bad Request` on tag builds was not caused by a concurrent master push run holding the same artifact name: a tag run with nothing else in flight failed identically, and so did a `workflow_dispatch` on the same tag ref. The run serialization is kept as hygiene but is no longer described as the fix.

Published as a prerelease, matching current workflow behavior.
