### PR TITLE
Make create-release.ps1 work under Windows PowerShell 5.1

### DIFF
--- a/scripts/create-release.ps1
+++ b/scripts/create-release.ps1
@@ -82,13 +82,31 @@ function Invoke-Native
         [string]$ErrorMessage
     )
 
-    $output = & $Executable @Arguments 2>&1
-    if ($LASTEXITCODE -ne 0)
+    # Windows PowerShell wraps a native command's stderr in ErrorRecord objects when it is
+    # redirected with 2>&1, and under $ErrorActionPreference = 'Stop' those raise a terminating
+    # error even when the command exits 0. Git writes routine progress to stderr, so 'checkout',
+    # 'push', 'pull', and 'fetch' all trip that. Relax the preference for the call itself and let
+    # the exit code decide, which is what PowerShell 7 does with the same redirection.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try
+    {
+        $output = & $Executable @Arguments 2>&1 | ForEach-Object {
+            if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.ToString() } else { $_ }
+        }
+        $exitCode = $LASTEXITCODE
+    }
+    finally
+    {
+        $ErrorActionPreference = $previousPreference
+    }
+
+    if ($exitCode -ne 0)
     {
         $joined = ($output | Out-String).Trim()
         $message = if ([string]::IsNullOrWhiteSpace($ErrorMessage))
         {
-            "$Executable $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+            "$Executable $($Arguments -join ' ') failed with exit code $exitCode."
         }
         else
         {


### PR DESCRIPTION
`Invoke-Native` redirects native stderr with `2>&1` while `$ErrorActionPreference` is `'Stop'`. Windows PowerShell wraps those lines in `ErrorRecord` objects, which raise a terminating error even when the command exits 0. Git writes routine progress to stderr, so cutting 1.8.2 threw on `git checkout -b release-1.8.2` **after it had already succeeded**, and the rollback's `git checkout --force master` threw the same way — which is the only error that surfaced.

Works as written under `pwsh` 7, which turns the same redirection into plain strings. Fails under `powershell.exe` 5.1.

Relax the preference for the call itself, stringify any `ErrorRecord`s, and decide on the captured exit code.

Verified under 5.1: `git checkout -b` now returns its stderr text instead of throwing, and a genuine failure (`git rev-parse nonexistent-ref`) still throws with exit code 128.