### PR TITLE
Release 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-08-17
+
 ### Fixed
 
 - Fixed the `WinVerifyTrust` interop declaration in `src/TrayToolbar/Services/AuthenticodeUpdateSignatureVerifier.cs`, which made every automatic update fail verification. `[MarshalAs(UnmanagedType.LPStruct)]` on the already-by-ref `in Guid actionId` parameter passed a pointer to a pointer, so `WinVerifyTrust` could not resolve `WINTRUST_ACTION_GENERIC_VERIFY_V2` and returned `TRUST_E_PROVIDER_UNKNOWN` (`0x800B0001`) for every file, signed or not ([#101](https://github.com/brondavies/TrayToolbar/issues/101)).
@@ -103,7 +105,8 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.1...HEAD
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.2...HEAD
+[1.8.2]: https://github.com/brondavies/TrayToolbar/compare/v1.8.1...v1.8.2
 [1.8.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.8.1
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1
 [1.7.0]: https://github.com/brondavies/TrayToolbar/compare/v1.6.2...v1.7.0

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,7 +7,7 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
-## 1.8.1
+## 1.8.2
 
 ## Highlights
 

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.8.1</Version>
+    <Version>1.8.2</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.1.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.8.2.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
﻿Release 1.8.2.

- Bump the version in `TrayToolbar.csproj` and `app.manifest`
- Roll `CHANGELOG.md` and `docs/release-notes.md`

The publish run signs the portable zips, creates tag `v
1.8.2
`, and publishes the prerelease.
