### PR TITLE
Fix create-release.ps1 run lookups under Windows PowerShell 5.1

### DIFF
--- a/scripts/create-release.ps1
+++ b/scripts/create-release.ps1
@@ -411,7 +411,12 @@ function Get-WorkflowRuns
         return @()
     }
 
-    return @($json | ConvertFrom-Json | Where-Object { $_.name -eq $WorkflowName })
+    # Windows PowerShell's ConvertFrom-Json emits a JSON array as a single Object[] pipeline item
+    # instead of enumerating it, so piping it straight into Where-Object filters the whole array as
+    # one object and every downstream Select-Object -First 1 hands back the entire collection.
+    # Assigning first and piping the variable enumerates in both Windows PowerShell and PowerShell 7.
+    $runs = $json | ConvertFrom-Json
+    return @($runs | Where-Object { $_.name -eq $WorkflowName })
 }
 
 function Stop-ValidationRun
@@ -479,7 +484,9 @@ function Wait-ForRun
         }
 
         $stepsJson = Invoke-Gh 'api' "repos/{owner}/{repo}/actions/runs/$RunId/jobs" '--jq' '[.jobs[0].steps[] | select(.status == "in_progress") | .name]'
-        $steps = @($stepsJson | ConvertFrom-Json)
+        # Same Windows PowerShell array-enumeration caveat as Get-WorkflowRuns.
+        $parsedSteps = $stepsJson | ConvertFrom-Json
+        $steps = @($parsedSteps)
         if ($steps.Count -gt 0 -and $steps[0] -ne $lastStep)
         {
             $lastStep = $steps[0]


### PR DESCRIPTION
Second Windows PowerShell 5.1 incompatibility in the release script, found cutting 1.8.2.

`ConvertFrom-Json` emits a JSON array as a single `Object[]` pipeline item instead of enumerating it. Piping it straight into `Where-Object` filters the whole array as one object — `$_.name -eq $WorkflowName` member-enumerates to a non-empty array, which is truthy — so the array passes the filter intact and `Select-Object -First 1` hands back the entire collection.

The failure:

```
gh run cancel 32057286363 32057265304 32057008463 ... failed with exit code 1.
invalid run-id "32057286363 32057265304 32057008463 ..."
```

`"$($run.databaseId)"` member-enumerated all ten ids into one argument. That left a stale signing run queued ahead of the publish run on the shared `portable-release-signing` group (`cancel-in-progress: false`), where it would have stalled the release waiting on a SignPath approval for a superseded commit.

Assign before piping in `Get-WorkflowRuns` and `Wait-ForRun`; a variable pipe enumerates in both editions.

Verified under 5.1: the filter returns 2 of 3 rows, `Select-Object -First 1` yields a single `PSCustomObject` with `databaseId` `1`, and the steps array parses to 2 elements.

**Do not merge until the 1.8.2 publish run finishes** — a push to master queues another signing run behind it on the shared group and costs two more SignPath approvals.
