### PR TITLE
Fix #78, #82, #86, #100; add launch logging (#85); CodeQL v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -60,7 +60,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -85,6 +85,6 @@ jobs:
         msbuild .\TrayToolbar.sln /p:Configuration=Debug /p:Platform=${{ matrix.Platform }}
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-09-02
+
 ### Added
 
 - Added optional launch logging, configured only in the JSON file and off by default: `LaunchLogEnabled`, `LaunchLogFile`, and `LaunchLogFormat` with `csv` (default), `tsv`, `jsonl`, `syslog`, and `cef` formats. Every format uses ISO-8601 timestamps and captures the timestamp, username, menu item name, and target path ([#85](https://github.com/brondavies/TrayToolbar/issues/85)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 ## [Unreleased]
 
+### Added
+
+- Added optional launch logging, configured only in the JSON file and off by default: `LaunchLogEnabled`, `LaunchLogFile`, and `LaunchLogFormat` with `csv` (default), `tsv`, `jsonl`, `syslog`, and `cef` formats. Every format uses ISO-8601 timestamps and captures the timestamp, username, menu item name, and target path ([#85](https://github.com/brondavies/TrayToolbar/issues/85)).
+- Added a spinner overlay that animates on a tray icon while its menu is loading, and a click during loading now opens the menu automatically once it is ready ([#82](https://github.com/brondavies/TrayToolbar/issues/82)).
+
+### Changed
+
+- Updated the CodeQL workflow to `github/codeql-action` v4 ahead of the v3 deprecation in December 2026.
+
+### Fixed
+
+- "Show links to folders as submenus" no longer hangs when a folder link points back at the scanned folder or an already-expanded target; cyclic links now appear as regular menu items ([#78](https://github.com/brondavies/TrayToolbar/issues/78)).
+- Right-clicking an item in a submenu that opened to the left no longer leaves submenus stuck open on screen; every dropdown suspended for a right-click is restored no matter which item receives the click ([#86](https://github.com/brondavies/TrayToolbar/issues/86)).
+- Advertised (MSI) shortcuts, such as those created by Office and CorelDRAW installers, launch correctly again. TrayToolbar now shell-executes the `.lnk` itself instead of the stub target path these shortcuts report ([#100](https://github.com/brondavies/TrayToolbar/issues/100)).
+
 ## [1.8.2] - 2026-08-17
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 ## Open GitHub feature requests
 
-- [ ] Add optional launch logging with a simple file format and configurable log path/name; capture item name, target path, timestamp, and username. (#85)
 - [ ] Add a clickable link to the project's GitHub releases page from Settings or a new About dialog. (#84)
 - [ ] Expand drag-and-drop support:
 	- [ ] Allow dragging files and folders out of TrayToolbar menus into Explorer and other app windows. (#79, #8)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -206,6 +206,9 @@ Serialization uses `System.Text.Json` with indented output.
 | `NotifyOnUpdateAvailable` | `bool` | `false` | Yes | Requires `CheckForUpdates = true`; also enables the periodic update timer. |
 | `UpdateCheckInterval` | `double` | `1440` | Yes | Minutes between background update checks. Default is 1 day. |
 | `ShowToolTips` | `bool` | `false` | Yes | Shows full file or folder paths as tooltips on menu items. |
+| `LaunchLogEnabled` | `bool` | `false` | Yes | Enables launch logging. JSON-config only; not exposed in the settings UI. |
+| `LaunchLogFile` | `string?` | `null` | Yes | Launch log path. Environment variables are expanded. Defaults to `launch.log` in the profile folder. |
+| `LaunchLogFormat` | `string?` | `null` | Yes | `csv` (default), `tsv`, `jsonl`, `syslog`, or `cef`. Timestamps are ISO-8601 in every format. |
 | `Folders` | `FolderConfig[]` | `[]` | Yes | Folder list displayed as tray icons and menus. In practice the first-run UI seeds one default folder before save. |
 
 ### Launch policy modes
@@ -217,6 +220,31 @@ Serialization uses `System.Text.Json` with indented output.
 | `LocalOnly` | Local files and folders whose resolved targets stay within approved roots, plus trusted TrayToolbar GitHub Releases URLs. | UNC paths, non-release remote URLs, and local shortcut targets that resolve outside approved roots. |
 
 Approved roots are the application root plus configured folder paths.
+
+### Launch logging
+
+Optional and off by default; configured only in the JSON file (no settings UI). When `LaunchLogEnabled`
+is `true`, every menu item launch appends one entry capturing the timestamp (ISO-8601 with UTC offset),
+username, menu item name, and target path.
+
+```json
+{
+  "LaunchLogEnabled": true,
+  "LaunchLogFile": "%LOCALAPPDATA%\\TrayToolbar\\launch.log",
+  "LaunchLogFormat": "jsonl"
+}
+```
+
+| Format | Entry style |
+| --- | --- |
+| `csv` (default) | RFC 4180-style fields; a header row is written when the file is created. |
+| `tsv` | Tab-separated with a header row; tabs and newlines in values become spaces. |
+| `jsonl` | One JSON object per line: `{"timestamp": ..., "user": ..., "name": ..., "target": ...}`. |
+| `syslog` | RFC 5424 lines (`<14>1 ...`) with `user`, `name`, and `target` in the message. |
+| `cef` | Common Event Format with `rt`, `suser`, `fname`, and `filePath` extensions. |
+
+Unknown format values fall back to `csv`. Logging failures are swallowed, so a bad path or an
+unwritable file never blocks a launch.
 
 ### Folder entries
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -7,6 +7,17 @@ This file stays as the supplemental narrative release summary for highlights, ro
 - GitHub release assets: <https://github.com/brondavies/TrayToolbar/releases>
 - Update and packaging trust boundary: [`update-security.md`](update-security.md)
 
+## 1.8.3
+
+## Highlights
+
+- Advertised shortcuts launch again. Shortcuts written by MSI installers (Microsoft Office, CorelDRAW, and similar) report a stub target path instead of the real application, so TrayToolbar now launches the shortcut itself and lets Windows resolve the target.
+- "Show links to folders as submenus" no longer hangs. A folder link pointing back into the folder being scanned recursed until the app froze; cyclic links now appear as regular menu items.
+- Loading feedback. A tray icon shows a spinner overlay while its menu is being built, and a click during loading opens the menu as soon as it is ready instead of being ignored.
+- Stuck submenus fixed. Right-clicking inside a submenu that opened toward the left could leave submenus orphaned on screen until restart; every suspended menu is now restored no matter which item receives the click.
+- Optional launch logging. Set `LaunchLogEnabled` in the configuration file to record which items are launched, by whom, and when — in `csv`, `tsv`, `jsonl`, `syslog`, or `cef` format with ISO-8601 timestamps, written off the launching thread. Off by default; see [`developer-guide.md`](developer-guide.md) for the settings.
+- **Full changelog**: see [`../CHANGELOG.md`](../CHANGELOG.md).
+
 ## 1.8.2
 
 ## Highlights

--- a/src/TrayToolbar.Tests/LaunchLoggerTests.cs
+++ b/src/TrayToolbar.Tests/LaunchLoggerTests.cs
@@ -154,7 +154,7 @@ public class LaunchLoggerTests
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
         Assert.AreEqual(1, lines.Length);
-        StringAssert.StartsWith(lines[0], "CEF:0|brondavies|TrayToolbar|");
+        StringAssert.StartsWith(lines[0], "CEF:0|brontech|TrayToolbar|");
         StringAssert.Contains(lines[0], $"rt={TestTimestamp}");
         StringAssert.Contains(lines[0], "suser=testuser");
         StringAssert.Contains(lines[0], @"fname=Name\=Equals");

--- a/src/TrayToolbar.Tests/LaunchLoggerTests.cs
+++ b/src/TrayToolbar.Tests/LaunchLoggerTests.cs
@@ -54,6 +54,7 @@ public class LaunchLoggerTests
         var fileSystem = Setup();
 
         LaunchLogger.Log(new TrayToolbarConfiguration(), "Notes", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
 
         Assert.IsFalse(new TrayToolbarConfiguration().LaunchLogEnabled);
         Assert.IsFalse(fileSystem.FileExists(DefaultLogFile));
@@ -69,6 +70,7 @@ public class LaunchLoggerTests
 
         LaunchLogger.Log(configuration, "Notes, with comma", @"C:\Root\Notes.lnk");
         LaunchLogger.Log(configuration, "Second", @"C:\Root\Second.lnk");
+        LaunchLogger.Flush();
 
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -87,6 +89,7 @@ public class LaunchLoggerTests
         var configuration = EnabledConfiguration("tsv");
 
         LaunchLogger.Log(configuration, "Notes\twith tab", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
 
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -104,6 +107,7 @@ public class LaunchLoggerTests
         var configuration = EnabledConfiguration("jsonl");
 
         LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
 
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -125,6 +129,7 @@ public class LaunchLoggerTests
         var configuration = EnabledConfiguration("syslog");
 
         LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
 
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -144,6 +149,7 @@ public class LaunchLoggerTests
         var configuration = EnabledConfiguration("cef");
 
         LaunchLogger.Log(configuration, "Name=Equals", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
 
         var lines = fileSystem.GetFileContents(DefaultLogFile)
             .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
@@ -167,6 +173,7 @@ public class LaunchLoggerTests
             var configuration = EnabledConfiguration(file: @"%TRAYTOOLBAR_TEST_LOGDIR%\launches.csv");
 
             LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+            LaunchLogger.Flush();
 
             Assert.IsTrue(fileSystem.FileExists(@"C:\Logs\launches.csv"));
             Assert.IsFalse(fileSystem.FileExists(DefaultLogFile));
@@ -186,6 +193,7 @@ public class LaunchLoggerTests
         var configuration = EnabledConfiguration(file: "::::invalid::::");
 
         LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+        LaunchLogger.Flush();
         // no exception means logging can never break a launch
     }
 

--- a/src/TrayToolbar.Tests/LaunchLoggerTests.cs
+++ b/src/TrayToolbar.Tests/LaunchLoggerTests.cs
@@ -1,0 +1,203 @@
+using System.Text.Json;
+
+using TrayToolbar.Models;
+using TrayToolbar.Services;
+
+namespace TrayToolbar.Tests;
+
+[TestClass]
+public class LaunchLoggerTests
+{
+    static readonly DateTimeOffset TestTime = new(2026, 9, 2, 13, 45, 30, 123, TimeSpan.FromHours(-6));
+    const string TestTimestamp = "2026-09-02T13:45:30.123-06:00";
+    const string ProfileFolder = @"C:\Profile\TrayToolbar";
+
+    sealed class LaunchLoggerStateScope : IDisposable
+    {
+        readonly Func<DateTimeOffset> clock = LaunchLogger.Clock;
+        readonly Func<string> userName = LaunchLogger.UserName;
+
+        public void Dispose()
+        {
+            LaunchLogger.Clock = clock;
+            LaunchLogger.UserName = userName;
+        }
+    }
+
+    static FakeFileSystem Setup()
+    {
+        var fileSystem = new FakeFileSystem();
+        ConfigHelper.FileSystem = fileSystem;
+        ConfigHelper.ProfileFolder = ProfileFolder;
+        LaunchLogger.Clock = () => TestTime;
+        LaunchLogger.UserName = () => "testuser";
+        return fileSystem;
+    }
+
+    static TrayToolbarConfiguration EnabledConfiguration(string? format = null, string? file = null)
+    {
+        return new TrayToolbarConfiguration
+        {
+            LaunchLogEnabled = true,
+            LaunchLogFormat = format,
+            LaunchLogFile = file,
+        };
+    }
+
+    static string DefaultLogFile => Path.Combine(ProfileFolder, LaunchLogger.DefaultLogFileName);
+
+    [TestMethod]
+    public void Log_is_disabled_by_default()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+
+        LaunchLogger.Log(new TrayToolbarConfiguration(), "Notes", @"C:\Root\Notes.lnk");
+
+        Assert.IsFalse(new TrayToolbarConfiguration().LaunchLogEnabled);
+        Assert.IsFalse(fileSystem.FileExists(DefaultLogFile));
+    }
+
+    [TestMethod]
+    public void Log_writes_csv_by_default_with_header_and_iso8601_timestamp()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        var configuration = EnabledConfiguration();
+
+        LaunchLogger.Log(configuration, "Notes, with comma", @"C:\Root\Notes.lnk");
+        LaunchLogger.Log(configuration, "Second", @"C:\Root\Second.lnk");
+
+        var lines = fileSystem.GetFileContents(DefaultLogFile)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(3, lines.Length);
+        Assert.AreEqual("timestamp,user,name,target", lines[0]);
+        Assert.AreEqual($"{TestTimestamp},testuser,\"Notes, with comma\",C:\\Root\\Notes.lnk", lines[1]);
+        Assert.AreEqual($"{TestTimestamp},testuser,Second,C:\\Root\\Second.lnk", lines[2]);
+    }
+
+    [TestMethod]
+    public void Log_writes_tsv_with_header()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        var configuration = EnabledConfiguration("tsv");
+
+        LaunchLogger.Log(configuration, "Notes\twith tab", @"C:\Root\Notes.lnk");
+
+        var lines = fileSystem.GetFileContents(DefaultLogFile)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(2, lines.Length);
+        Assert.AreEqual("timestamp\tuser\tname\ttarget", lines[0]);
+        Assert.AreEqual($"{TestTimestamp}\ttestuser\tNotes with tab\tC:\\Root\\Notes.lnk", lines[1]);
+    }
+
+    [TestMethod]
+    public void Log_writes_jsonl_entries()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        var configuration = EnabledConfiguration("jsonl");
+
+        LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+
+        var lines = fileSystem.GetFileContents(DefaultLogFile)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(1, lines.Length);
+        using var document = JsonDocument.Parse(lines[0]);
+        Assert.AreEqual(TestTimestamp, document.RootElement.GetProperty("timestamp").GetString());
+        Assert.AreEqual("testuser", document.RootElement.GetProperty("user").GetString());
+        Assert.AreEqual("Notes", document.RootElement.GetProperty("name").GetString());
+        Assert.AreEqual(@"C:\Root\Notes.lnk", document.RootElement.GetProperty("target").GetString());
+        Assert.AreEqual(TestTime, DateTimeOffset.Parse(document.RootElement.GetProperty("timestamp").GetString()!));
+    }
+
+    [TestMethod]
+    public void Log_writes_rfc5424_syslog_lines()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        var configuration = EnabledConfiguration("syslog");
+
+        LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+
+        var lines = fileSystem.GetFileContents(DefaultLogFile)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(1, lines.Length);
+        StringAssert.StartsWith(lines[0], $"<14>1 {TestTimestamp} {Environment.MachineName} TrayToolbar ");
+        StringAssert.Contains(lines[0], "user=\"testuser\"");
+        StringAssert.Contains(lines[0], "name=\"Notes\"");
+        StringAssert.Contains(lines[0], "target=\"C:\\Root\\Notes.lnk\"");
+    }
+
+    [TestMethod]
+    public void Log_writes_cef_lines_with_escaped_extensions()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        var configuration = EnabledConfiguration("cef");
+
+        LaunchLogger.Log(configuration, "Name=Equals", @"C:\Root\Notes.lnk");
+
+        var lines = fileSystem.GetFileContents(DefaultLogFile)
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.AreEqual(1, lines.Length);
+        StringAssert.StartsWith(lines[0], "CEF:0|brondavies|TrayToolbar|");
+        StringAssert.Contains(lines[0], $"rt={TestTimestamp}");
+        StringAssert.Contains(lines[0], "suser=testuser");
+        StringAssert.Contains(lines[0], @"fname=Name\=Equals");
+        StringAssert.Contains(lines[0], @"filePath=C:\\Root\\Notes.lnk");
+    }
+
+    [TestMethod]
+    public void Log_writes_to_the_configured_file_and_expands_environment_variables()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        var fileSystem = Setup();
+        Environment.SetEnvironmentVariable("TRAYTOOLBAR_TEST_LOGDIR", @"C:\Logs");
+        try
+        {
+            var configuration = EnabledConfiguration(file: @"%TRAYTOOLBAR_TEST_LOGDIR%\launches.csv");
+
+            LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+
+            Assert.IsTrue(fileSystem.FileExists(@"C:\Logs\launches.csv"));
+            Assert.IsFalse(fileSystem.FileExists(DefaultLogFile));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("TRAYTOOLBAR_TEST_LOGDIR", null);
+        }
+    }
+
+    [TestMethod]
+    public void Log_swallows_write_failures()
+    {
+        using var scope = new ConfigHelperStateScope();
+        using var loggerScope = new LaunchLoggerStateScope();
+        Setup();
+        var configuration = EnabledConfiguration(file: "::::invalid::::");
+
+        LaunchLogger.Log(configuration, "Notes", @"C:\Root\Notes.lnk");
+        // no exception means logging can never break a launch
+    }
+
+    [TestMethod]
+    public void ParseFormat_defaults_to_csv_for_unknown_values()
+    {
+        Assert.AreEqual(LaunchLogger.LogFormat.Csv, LaunchLogger.ParseFormat(null));
+        Assert.AreEqual(LaunchLogger.LogFormat.Csv, LaunchLogger.ParseFormat("unknown"));
+        Assert.AreEqual(LaunchLogger.LogFormat.Csv, LaunchLogger.ParseFormat("CSV"));
+        Assert.AreEqual(LaunchLogger.LogFormat.Tsv, LaunchLogger.ParseFormat(" TSV "));
+        Assert.AreEqual(LaunchLogger.LogFormat.Jsonl, LaunchLogger.ParseFormat("jsonl"));
+        Assert.AreEqual(LaunchLogger.LogFormat.Syslog, LaunchLogger.ParseFormat("Syslog"));
+        Assert.AreEqual(LaunchLogger.LogFormat.Cef, LaunchLogger.ParseFormat("cef"));
+    }
+}

--- a/src/TrayToolbar.Tests/MenuItemCollectionTests.cs
+++ b/src/TrayToolbar.Tests/MenuItemCollectionTests.cs
@@ -1,0 +1,95 @@
+using System.Windows.Forms;
+
+using TrayToolbar.Models;
+
+namespace TrayToolbar.Tests;
+
+[TestClass]
+public class MenuItemCollectionTests
+{
+    [TestMethod]
+    public void CreateMenuItem_shows_cyclic_folder_links_as_regular_items()
+    {
+        using var scope = new ConfigHelperStateScope();
+        var fileSystem = new FakeFileSystem();
+        ConfigHelper.FileSystem = fileSystem;
+        var root = @"C:\Root";
+        var linkPath = Path.Combine(root, "Loop.lnk");
+        fileSystem.AddFile(linkPath);
+        fileSystem.AddFile(Path.Combine(root, "app.exe"));
+        var configuration = new TrayToolbarConfiguration { ShowFolderLinksAsSubMenus = true };
+        var collection = new MenuItemCollection(configuration, (_, _) => { }, (_, _) => { })
+        {
+            // The link resolves back to the folder being scanned; without the cycle
+            // guard this recursed until the app hung
+            ShortcutResolver = _ => root,
+        };
+        var folder = new FolderConfig(root) { Recursive = true };
+
+        collection.CreateMenuItem(linkPath, folder);
+
+        Assert.AreEqual(1, collection.Count);
+        Assert.AreEqual("Loop", collection[0].Name);
+        Assert.AreEqual(AccessibleRole.MenuItem, collection[0].AccessibleRole);
+        Assert.AreEqual(0, collection[0].DropDownItems.Count);
+    }
+
+    [TestMethod]
+    public void CreateMenuItem_still_expands_folder_links_to_other_folders_as_submenus()
+    {
+        using var scope = new ConfigHelperStateScope();
+        var fileSystem = new FakeFileSystem();
+        ConfigHelper.FileSystem = fileSystem;
+        var root = @"C:\Root";
+        var target = @"C:\Elsewhere";
+        var linkPath = Path.Combine(root, "Docs.lnk");
+        fileSystem.AddFile(linkPath);
+        fileSystem.AddDirectory(target);
+        fileSystem.AddFile(Path.Combine(target, "tool.exe"));
+        var configuration = new TrayToolbarConfiguration { ShowFolderLinksAsSubMenus = true };
+        var collection = new MenuItemCollection(configuration, (_, _) => { }, (_, _) => { })
+        {
+            ShortcutResolver = _ => target,
+        };
+        var folder = new FolderConfig(root) { Recursive = true };
+
+        collection.CreateMenuItem(linkPath, folder);
+
+        Assert.AreEqual(1, collection.Count);
+        Assert.AreEqual("Docs", collection[0].Name);
+        Assert.AreEqual(AccessibleRole.MenuPopup, collection[0].AccessibleRole);
+        Assert.AreEqual(1, collection[0].DropDownItems.Count);
+        Assert.AreEqual("tool.exe", collection[0].DropDownItems[0].Name);
+    }
+
+    [TestMethod]
+    public void CreateMenuItem_stops_mutual_folder_link_cycles()
+    {
+        using var scope = new ConfigHelperStateScope();
+        var fileSystem = new FakeFileSystem();
+        ConfigHelper.FileSystem = fileSystem;
+        var root = @"C:\Root";
+        var other = @"C:\Other";
+        var linkToOther = Path.Combine(root, "Other.lnk");
+        var linkBack = Path.Combine(other, "Root.lnk");
+        fileSystem.AddFile(linkToOther);
+        fileSystem.AddDirectory(other);
+        fileSystem.AddFile(linkBack);
+        var configuration = new TrayToolbarConfiguration { ShowFolderLinksAsSubMenus = true };
+        var collection = new MenuItemCollection(configuration, (_, _) => { }, (_, _) => { })
+        {
+            ShortcutResolver = path => path.Equals(linkToOther, StringComparison.OrdinalIgnoreCase) ? other : root,
+        };
+        var folder = new FolderConfig(root) { Recursive = true };
+
+        collection.CreateMenuItem(linkToOther, folder);
+
+        // Root.lnk points back at C:\Root which is already being expanded, so it must
+        // be rendered as a plain item inside the "Other" submenu instead of recursing
+        Assert.AreEqual(1, collection.Count);
+        Assert.AreEqual("Other", collection[0].Name);
+        Assert.AreEqual(1, collection[0].DropDownItems.Count);
+        Assert.AreEqual("Root", collection[0].DropDownItems[0].Name);
+        Assert.AreEqual(AccessibleRole.MenuItem, ((ToolStripMenuItem)collection[0].DropDownItems[0]).AccessibleRole);
+    }
+}

--- a/src/TrayToolbar.Tests/ProgramTests.cs
+++ b/src/TrayToolbar.Tests/ProgramTests.cs
@@ -119,6 +119,38 @@ public class ProgramTests
     }
 
     [TestMethod]
+    public void Launch_shell_executes_advertised_shortcuts_instead_of_the_reported_target()
+    {
+        using var scope = new ConfigHelperStateScope();
+        var processLauncher = new FakeProcessLauncher();
+        ConfigHelper.ProcessLauncher = processLauncher;
+
+        var tempDirectory = Path.Combine(Path.GetTempPath(), $"TrayToolbar-ShortcutTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDirectory);
+        var shortcutPath = Path.Combine(tempDirectory, "Advertised.lnk");
+        var targetPath = Path.Combine(Environment.SystemDirectory, "cmd.exe");
+
+        try
+        {
+            // An MSI advertised shortcut carries a Darwin descriptor; GetPath reports a stub,
+            // so the .lnk itself must be shell-executed for the launch to work
+            CreateShortcut(shortcutPath, targetPath, string.Empty, tempDirectory);
+            MakeShortcutAdvertised(shortcutPath);
+
+            var launched = Program.Launch(shortcutPath);
+
+            Assert.IsTrue(launched);
+            Assert.AreEqual(1, processLauncher.StartedProcesses.Count);
+            Assert.AreEqual(shortcutPath, processLauncher.StartedProcesses[0].FileName);
+            Assert.IsTrue(processLauncher.StartedProcesses[0].UseShellExecute);
+        }
+        finally
+        {
+            Directory.Delete(tempDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
     public void Launch_resolves_non_executable_shortcuts_without_arguments()
     {
         using var scope = new ConfigHelperStateScope();
@@ -205,11 +237,61 @@ public class ProgramTests
 
         if (runAsUser)
         {
-            SetShortcutRunAsUser(shortcutPath);
+            SetShortcutFlags(shortcutPath, SldfRunAsUser);
         }
     }
 
-    static void SetShortcutRunAsUser(string shortcutPath)
+    static void MakeShortcutAdvertised(string shortcutPath)
+    {
+        object? shellLink = null;
+        var block = IntPtr.Zero;
+
+        try
+        {
+            var shellLinkType = Type.GetTypeFromCLSID(ShellLinkClsid, throwOnError: true);
+            shellLink = Activator.CreateInstance(shellLinkType!);
+            Assert.IsNotNull(shellLink);
+
+            var persistFile = (IPersistFile)shellLink!;
+            persistFile.Load(shortcutPath, StgmReadWrite);
+
+            // EXP_DARWIN_LINK: DATABLOCK_HEADER + szDarwinID[260] (ANSI) + szwDarwinID[260] (wide);
+            // saving the block makes the shell set SLDF_HAS_DARWINID in the link header
+            const int blockSize = 4 + 4 + 260 + 520;
+            block = Marshal.AllocHGlobal(blockSize);
+            for (var offset = 0; offset < blockSize; offset += 4)
+            {
+                Marshal.WriteInt32(block, offset, 0);
+            }
+            Marshal.WriteInt32(block, 0, blockSize);
+            Marshal.WriteInt32(block, 4, unchecked((int)ExpDarwinIdSignature));
+            const string darwinId = "TestDarwinDescriptor";
+            var ansiId = System.Text.Encoding.ASCII.GetBytes(darwinId);
+            Marshal.Copy(ansiId, 0, block + 8, ansiId.Length);
+            var wideId = System.Text.Encoding.Unicode.GetBytes(darwinId);
+            Marshal.Copy(wideId, 0, block + 8 + 260, wideId.Length);
+
+            var dataList = (IShellLinkDataList)shellLink!;
+            dataList.AddDataBlock(block);
+            dataList.GetFlags(out var flags);
+            dataList.SetFlags(flags | SldfHasDarwinId);
+
+            persistFile.Save(shortcutPath, true);
+        }
+        finally
+        {
+            if (block != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(block);
+            }
+            if (shellLink != null && Marshal.IsComObject(shellLink))
+            {
+                Marshal.FinalReleaseComObject(shellLink);
+            }
+        }
+    }
+
+    static void SetShortcutFlags(string shortcutPath, uint additionalFlags)
     {
         object? shellLink = null;
 
@@ -224,7 +306,7 @@ public class ProgramTests
 
             var dataList = (IShellLinkDataList)shellLink!;
             dataList.GetFlags(out var flags);
-            dataList.SetFlags(flags | SldfRunAsUser);
+            dataList.SetFlags(flags | additionalFlags);
 
             persistFile.Save(shortcutPath, true);
         }
@@ -265,4 +347,6 @@ public class ProgramTests
     static readonly Guid ShellLinkClsid = new("00021401-0000-0000-C000-000000000046");
     const uint StgmReadWrite = 0x00000002;
     const uint SldfRunAsUser = 0x00002000;
+    const uint SldfHasDarwinId = 0x00001000;
+    const uint ExpDarwinIdSignature = 0xA0000006;
 }

--- a/src/TrayToolbar.Tests/SpinnerIconRendererTests.cs
+++ b/src/TrayToolbar.Tests/SpinnerIconRendererTests.cs
@@ -1,0 +1,21 @@
+using System.Drawing;
+
+using TrayToolbar.Controls;
+
+namespace TrayToolbar.Tests;
+
+[TestClass]
+public class SpinnerIconRendererTests
+{
+    [TestMethod]
+    public void RenderFrame_returns_an_icon_of_the_same_size_for_every_frame()
+    {
+        using var baseIcon = (Icon)SystemIcons.Application.Clone();
+
+        for (var frame = 0; frame < SpinnerIconRenderer.FrameCount; frame++)
+        {
+            using var rendered = SpinnerIconRenderer.RenderFrame(baseIcon, frame);
+            Assert.AreEqual(baseIcon.Size, rendered.Size);
+        }
+    }
+}

--- a/src/TrayToolbar.Tests/TestInfrastructure/FakeFileSystem.cs
+++ b/src/TrayToolbar.Tests/TestInfrastructure/FakeFileSystem.cs
@@ -71,6 +71,19 @@ internal sealed class FakeFileSystem : IFileSystem
         files[normalizedPath] = contents;
     }
 
+    public void AppendAllText(string path, string contents)
+    {
+        var normalizedPath = Normalize(path);
+        var directory = Path.GetDirectoryName(normalizedPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            CreateDirectory(directory);
+        }
+
+        files.TryGetValue(normalizedPath, out var existing);
+        files[normalizedPath] = (existing ?? string.Empty) + contents;
+    }
+
     public void DeleteFile(string path)
     {
         files.Remove(Normalize(path));

--- a/src/TrayToolbar/Controls/SpinnerIconRenderer.cs
+++ b/src/TrayToolbar/Controls/SpinnerIconRenderer.cs
@@ -1,0 +1,51 @@
+using System.Drawing.Drawing2D;
+
+using Windows.Win32;
+using Windows.Win32.UI.WindowsAndMessaging;
+
+namespace TrayToolbar.Controls;
+
+/// <summary>
+/// Renders tray icon frames with a spinner arc overlaid in the bottom-right corner
+/// to show that the menu is still loading
+/// </summary>
+internal static class SpinnerIconRenderer
+{
+    internal const int FrameCount = 8;
+
+    static readonly Color SpinnerColor = Color.FromArgb(0, 103, 192); // Windows accent blue
+    static readonly Color SpinnerBackground = Color.FromArgb(220, Color.White);
+
+    internal static Icon RenderFrame(Icon baseIcon, int frame)
+    {
+        var size = baseIcon.Size;
+        using var bitmap = new Bitmap(size.Width, size.Height);
+        using (var graphics = Graphics.FromImage(bitmap))
+        {
+            graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            graphics.DrawIcon(baseIcon, new Rectangle(Point.Empty, size));
+
+            var diameter = Math.Max(size.Width / 2, 8);
+            var badge = new Rectangle(size.Width - diameter, size.Height - diameter, diameter - 1, diameter - 1);
+            using var background = new SolidBrush(SpinnerBackground);
+            graphics.FillEllipse(background, badge);
+
+            var thickness = Math.Max(diameter / 5f, 1.5f);
+            var inset = thickness / 2f + 0.5f;
+            var arc = new RectangleF(badge.X + inset, badge.Y + inset, badge.Width - 2 * inset, badge.Height - 2 * inset);
+            using var pen = new Pen(SpinnerColor, thickness);
+            graphics.DrawArc(pen, arc, frame * (360f / FrameCount), 270f);
+        }
+
+        var handle = bitmap.GetHicon();
+        try
+        {
+            using var frameIcon = Icon.FromHandle(handle);
+            return (Icon)frameIcon.Clone();
+        }
+        finally
+        {
+            PInvoke.DestroyIcon((HICON)handle);
+        }
+    }
+}

--- a/src/TrayToolbar/Extensions/MenuItemExtensions.cs
+++ b/src/TrayToolbar/Extensions/MenuItemExtensions.cs
@@ -1,13 +1,19 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 
 namespace TrayToolbar.Extensions;
 
 public static class MenuItemExtensions
 {
-    public static void SetAutoClose(this ToolStripDropDown menu, bool autoClose)
+    /// <summary>
+    /// Sets <see cref="ToolStripDropDown.AutoClose"/> on the menu and every ancestor dropdown
+    /// and returns the dropdowns that were changed so callers can restore exactly the same set.
+    /// </summary>
+    public static List<ToolStripDropDown> SetAutoClose(this ToolStripDropDown menu, bool autoClose)
     {
+        var affected = new List<ToolStripDropDown>();
         var dropDown = menu;
         dropDown.AutoClose = autoClose;
+        affected.Add(dropDown);
         while (dropDown.OwnerItem != null && dropDown.OwnerItem is ToolStripDropDownItem owner)
         {
             //There's an extra level to get to the parent menu
@@ -20,6 +26,8 @@ public static class MenuItemExtensions
                 break;
             }
             dropDown.AutoClose = autoClose;
+            affected.Add(dropDown);
         }
+        return affected;
     }
 }

--- a/src/TrayToolbar/Models/MenuItemCollection.cs
+++ b/src/TrayToolbar/Models/MenuItemCollection.cs
@@ -21,11 +21,13 @@ public class MenuItemCollection : ObservableCollection<ToolStripMenuItem>
     public TrayToolbarConfiguration Configuration { get; set; }
     public ToolStripItemClickedEventHandler ClickHandler { get; set; }
     public MouseEventHandler MouseDownHandler { get; set; }
+    internal Func<string, string>? ShortcutResolver { get; set; }
 
     internal void CreateMenuItem(
         string file,
         FolderConfig folder,
-        string menuPath = "")
+        string menuPath = "",
+        HashSet<string>? expandedTargets = null)
     {
         if (menuPath.Length > Configuration.MaxMenuPath) return; //guard against long paths or infinite loops
         var parentPath = Path.GetDirectoryName(file);
@@ -40,16 +42,25 @@ public class MenuItemCollection : ObservableCollection<ToolStripMenuItem>
         var relativePath = Path.GetRelativePath(folderPath, parentPath ?? folderPath);
         if (relativePath == ".") relativePath = "";
         var scanner = new FolderScanner(ConfigHelper.FileSystem);
-        if (scanner.TryResolveFolderLinkTarget(file, Configuration, out var targetPath))
+        if (scanner.TryResolveFolderLinkTarget(file, Configuration, out var targetPath, ShortcutResolver))
         {
-            var submenuName = Path.GetFileNameWithoutExtension(file);
-            var subfolder = folder.WithPath(targetPath);
-            var newRoot = Path.Combine(menuPath, relativePath, submenuName);
-            foreach (var f in EnumerateFiles(targetPath, folder.Recursive, Configuration))
+            // Track the chain of expanded link targets so a link pointing back at the
+            // scanned folder (or an already-expanded target) can't recurse forever
+            expandedTargets ??= new HashSet<string>(StringComparer.OrdinalIgnoreCase) { NormalizeFolderPath(folderPath) };
+            var normalizedTarget = NormalizeFolderPath(targetPath);
+            if (!expandedTargets.Contains(normalizedTarget))
             {
-                CreateMenuItem(f, subfolder, newRoot);
+                var submenuName = Path.GetFileNameWithoutExtension(file);
+                var subfolder = folder.WithPath(targetPath);
+                var newRoot = Path.Combine(menuPath, relativePath, submenuName);
+                var childTargets = new HashSet<string>(expandedTargets, StringComparer.OrdinalIgnoreCase) { normalizedTarget };
+                foreach (var f in EnumerateFiles(targetPath, folder.Recursive, Configuration))
+                {
+                    CreateMenuItem(f, subfolder, newRoot, childTargets);
+                }
+                return; // Skip adding the link itself, as it's now a submenu
             }
-            return; // Skip adding the link itself, as it's now a submenu
+            // Cyclic link: fall through and show it as a regular menu item
         }
         var menuName = (Configuration.HideFileExtensions || file.FileExtension().IsOneOf(".lnk", ".url"))
             ? Path.GetFileNameWithoutExtension(file)
@@ -174,6 +185,18 @@ public class MenuItemCollection : ObservableCollection<ToolStripMenuItem>
     {
         var eventArgs = new ToolStripItemClickedEventArgs(menu);
         return (s, e) => ClickHandler.Invoke(s, eventArgs);
+    }
+
+    private static string NormalizeFolderPath(string path)
+    {
+        try
+        {
+            return Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+        }
+        catch
+        {
+            return path;
+        }
     }
 
     internal static IEnumerable<string> EnumerateFiles(string path, bool recursive, TrayToolbarConfiguration config)

--- a/src/TrayToolbar/Models/TrayToolbarConfiguration.cs
+++ b/src/TrayToolbar/Models/TrayToolbarConfiguration.cs
@@ -100,6 +100,23 @@ public class TrayToolbarConfiguration
     /// </summary>
     public bool ShowToolTips { get; set; }
 
+    /// <summary>
+    /// Whether menu item launches are logged. Off by default. Configuration-file only; no UI.
+    /// </summary>
+    public bool LaunchLogEnabled { get; set; }
+
+    /// <summary>
+    /// Full path of the launch log file. Environment variables are expanded.
+    /// Defaults to launch.log in the TrayToolbar profile folder.
+    /// </summary>
+    public string? LaunchLogFile { get; set; }
+
+    /// <summary>
+    /// Launch log format: csv (default), tsv, jsonl, syslog, or cef.
+    /// Timestamps are ISO-8601 in every format.
+    /// </summary>
+    public string? LaunchLogFormat { get; set; }
+
     [Obsolete("Folder is obsolete", true)]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? Folder

--- a/src/TrayToolbar/Program.cs
+++ b/src/TrayToolbar/Program.cs
@@ -57,6 +57,7 @@ internal static class Program
             File.WriteAllText(Path.Combine(ConfigHelper.ApplicationRoot, $"Error-{DateTime.Now:yyyyMMddHHmmss}.txt"), $"{e}");
         }
         HotKeys.UnregisterAll();
+        LaunchLogger.Flush();
     }
 
     internal static bool Launch(string fileName)

--- a/src/TrayToolbar/Services/IFileSystem.cs
+++ b/src/TrayToolbar/Services/IFileSystem.cs
@@ -7,6 +7,7 @@ internal interface IFileSystem
     void CreateDirectory(string path);
     string ReadAllText(string path);
     void WriteAllText(string path, string contents);
+    void AppendAllText(string path, string contents);
     void DeleteFile(string path);
     void MoveFile(string sourceFileName, string destFileName);
     IEnumerable<string> EnumerateFileSystemEntries(string path);

--- a/src/TrayToolbar/Services/LaunchLogger.cs
+++ b/src/TrayToolbar/Services/LaunchLogger.cs
@@ -26,6 +26,14 @@ internal static class LaunchLogger
         Cef,
     }
 
+    static readonly object WriteSync = new();
+    static Task PendingWrites = Task.CompletedTask;
+
+    /// <summary>
+    /// Captures the entry details immediately and queues the file write to a background
+    /// thread so logging never delays the launch. Writes are serialized so entries
+    /// cannot interleave.
+    /// </summary>
     internal static void Log(TrayToolbarConfiguration? configuration, string itemName, string targetPath)
     {
         try
@@ -36,8 +44,48 @@ internal static class LaunchLogger
                 .Or(Path.Combine(ConfigHelper.ProfileFolder, DefaultLogFileName))!
                 .ToLocalPath();
             var timestamp = Clock().ToString("yyyy-MM-ddTHH:mm:ss.fffK", CultureInfo.InvariantCulture);
+            var user = UserName();
+            lock (WriteSync)
+            {
+                PendingWrites = PendingWrites.ContinueWith(
+                    _ => WriteEntry(format, path, timestamp, user, itemName, targetPath),
+                    CancellationToken.None,
+                    TaskContinuationOptions.None,
+                    TaskScheduler.Default);
+            }
+        }
+        catch
+        {
+            // Logging must never interfere with launching
+        }
+    }
+
+    /// <summary>
+    /// Waits for all queued log writes to finish. Called before the process exits
+    /// and by tests that assert on log contents.
+    /// </summary>
+    internal static void Flush()
+    {
+        Task pending;
+        lock (WriteSync)
+        {
+            pending = PendingWrites;
+        }
+        try
+        {
+            pending.Wait();
+        }
+        catch
+        {
+        }
+    }
+
+    static void WriteEntry(LogFormat format, string path, string timestamp, string user, string name, string target)
+    {
+        try
+        {
             var header = NeedsHeader(format, path) ? FormatHeader(format) + Environment.NewLine : string.Empty;
-            var line = FormatEntry(format, timestamp, UserName(), itemName, targetPath);
+            var line = FormatEntry(format, timestamp, user, name, target);
             ConfigHelper.FileSystem.AppendAllText(path, header + line + Environment.NewLine);
         }
         catch

--- a/src/TrayToolbar/Services/LaunchLogger.cs
+++ b/src/TrayToolbar/Services/LaunchLogger.cs
@@ -128,7 +128,7 @@ internal static class LaunchLogger
                 $"<14>1 {timestamp} {Environment.MachineName} TrayToolbar {Environment.ProcessId} LAUNCH - " +
                 $"user=\"{SingleLine(user)}\" name=\"{SingleLine(name)}\" target=\"{SingleLine(target)}\"",
             LogFormat.Cef =>
-                $"CEF:0|brondavies|TrayToolbar|{ConfigHelper.ApplicationVersion}|launch|Item launched|3|" +
+                $"CEF:0|brontech|TrayToolbar|{ConfigHelper.ApplicationVersion}|launch|Item launched|3|" +
                 $"rt={CefField(timestamp)} suser={CefField(user)} fname={CefField(name)} filePath={CefField(target)}",
             _ => string.Join(',',
                 CsvField(timestamp), CsvField(user), CsvField(name), CsvField(target)),

--- a/src/TrayToolbar/Services/LaunchLogger.cs
+++ b/src/TrayToolbar/Services/LaunchLogger.cs
@@ -1,0 +1,113 @@
+using System.Globalization;
+using System.Text.Json;
+
+using TrayToolbar.Extensions;
+using TrayToolbar.Models;
+
+namespace TrayToolbar.Services;
+
+/// <summary>
+/// Optional launch logging. Configuration-file only; disabled by default.
+/// Captures item name, target path, timestamp (ISO-8601 in every format), and username.
+/// </summary>
+internal static class LaunchLogger
+{
+    internal const string DefaultLogFileName = "launch.log";
+
+    internal static Func<DateTimeOffset> Clock { get; set; } = () => DateTimeOffset.Now;
+    internal static Func<string> UserName { get; set; } = () => Environment.UserName;
+
+    internal enum LogFormat
+    {
+        Csv,
+        Tsv,
+        Jsonl,
+        Syslog,
+        Cef,
+    }
+
+    internal static void Log(TrayToolbarConfiguration? configuration, string itemName, string targetPath)
+    {
+        try
+        {
+            if (configuration is not { LaunchLogEnabled: true }) return;
+            var format = ParseFormat(configuration.LaunchLogFormat);
+            var path = configuration.LaunchLogFile
+                .Or(Path.Combine(ConfigHelper.ProfileFolder, DefaultLogFileName))!
+                .ToLocalPath();
+            var timestamp = Clock().ToString("yyyy-MM-ddTHH:mm:ss.fffK", CultureInfo.InvariantCulture);
+            var header = NeedsHeader(format, path) ? FormatHeader(format) + Environment.NewLine : string.Empty;
+            var line = FormatEntry(format, timestamp, UserName(), itemName, targetPath);
+            ConfigHelper.FileSystem.AppendAllText(path, header + line + Environment.NewLine);
+        }
+        catch
+        {
+            // Logging must never interfere with launching
+        }
+    }
+
+    internal static LogFormat ParseFormat(string? format)
+    {
+        return format?.Trim().ToLowerInvariant() switch
+        {
+            "tsv" => LogFormat.Tsv,
+            "jsonl" => LogFormat.Jsonl,
+            "syslog" => LogFormat.Syslog,
+            "cef" => LogFormat.Cef,
+            _ => LogFormat.Csv,
+        };
+    }
+
+    static bool NeedsHeader(LogFormat format, string path)
+    {
+        return (format is LogFormat.Csv or LogFormat.Tsv) && !ConfigHelper.FileSystem.FileExists(path);
+    }
+
+    static string FormatHeader(LogFormat format)
+    {
+        var separator = format == LogFormat.Tsv ? '\t' : ',';
+        return string.Join(separator, "timestamp", "user", "name", "target");
+    }
+
+    static string FormatEntry(LogFormat format, string timestamp, string user, string name, string target)
+    {
+        return format switch
+        {
+            LogFormat.Tsv => string.Join('\t',
+                TsvField(timestamp), TsvField(user), TsvField(name), TsvField(target)),
+            LogFormat.Jsonl => JsonSerializer.Serialize(new { timestamp, user, name, target }),
+            LogFormat.Syslog =>
+                $"<14>1 {timestamp} {Environment.MachineName} TrayToolbar {Environment.ProcessId} LAUNCH - " +
+                $"user=\"{SingleLine(user)}\" name=\"{SingleLine(name)}\" target=\"{SingleLine(target)}\"",
+            LogFormat.Cef =>
+                $"CEF:0|brondavies|TrayToolbar|{ConfigHelper.ApplicationVersion}|launch|Item launched|3|" +
+                $"rt={CefField(timestamp)} suser={CefField(user)} fname={CefField(name)} filePath={CefField(target)}",
+            _ => string.Join(',',
+                CsvField(timestamp), CsvField(user), CsvField(name), CsvField(target)),
+        };
+    }
+
+    static string CsvField(string value)
+    {
+        if (value.IndexOfAny([',', '"', '\r', '\n']) < 0)
+        {
+            return value;
+        }
+        return $"\"{value.Replace("\"", "\"\"")}\"";
+    }
+
+    static string TsvField(string value)
+    {
+        return value.Replace('\t', ' ').Replace('\r', ' ').Replace('\n', ' ');
+    }
+
+    static string SingleLine(string value)
+    {
+        return value.Replace('\r', ' ').Replace('\n', ' ');
+    }
+
+    static string CefField(string value)
+    {
+        return SingleLine(value).Replace(@"\", @"\\").Replace("=", @"\=");
+    }
+}

--- a/src/TrayToolbar/Services/ShortcutTargetResolver.cs
+++ b/src/TrayToolbar/Services/ShortcutTargetResolver.cs
@@ -150,7 +150,8 @@ internal static class ShortcutTargetResolver
                 FormatIconLocation(iconLocation, iconIndex),
                 string.Empty,
                 MapWindowStyle(showCommand),
-                (flags & SldfRunAsUser) != 0);
+                (flags & SldfRunAsUser) != 0,
+                (flags & SldfHasDarwinId) != 0);
             return true;
         }
         catch
@@ -165,6 +166,13 @@ internal static class ShortcutTargetResolver
 
     static bool CanCreateDirectShortcutStartInfo(FileShortcutLaunchInfo launchInfo)
     {
+        // Advertised (MSI) shortcuts report a stub path from GetPath; only the shell can
+        // resolve the Darwin descriptor, so the .lnk itself must be launched.
+        if (launchInfo.IsAdvertised)
+        {
+            return false;
+        }
+
         if (!launchInfo.TargetPath.HasValue()
             || launchInfo.TargetPath.Is(launchInfo.ShortcutPath)
             || (!File.Exists(launchInfo.TargetPath) && !Directory.Exists(launchInfo.TargetPath)))
@@ -287,7 +295,8 @@ internal static class ShortcutTargetResolver
         string IconLocation,
         string RelativePath,
         ProcessWindowStyle WindowStyle,
-        bool RunAsUser);
+        bool RunAsUser,
+        bool IsAdvertised);
 
     [ComImport]
     [Guid("000214F9-0000-0000-C000-000000000046")]
@@ -344,4 +353,5 @@ internal static class ShortcutTargetResolver
     const uint SlgpRawPath = 0x00000004;
     const uint StgmRead = 0;
     const uint SldfRunAsUser = 0x00002000;
+    const uint SldfHasDarwinId = 0x00001000;
 }

--- a/src/TrayToolbar/Services/SystemFileSystem.cs
+++ b/src/TrayToolbar/Services/SystemFileSystem.cs
@@ -12,6 +12,16 @@ internal sealed class SystemFileSystem : IFileSystem
 
     public void WriteAllText(string path, string contents) => File.WriteAllText(path, contents);
 
+    public void AppendAllText(string path, string contents)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.AppendAllText(path, contents);
+    }
+
     public void DeleteFile(string path) => File.Delete(path);
 
     public void MoveFile(string sourceFileName, string destFileName) => File.Move(sourceFileName, destFileName);

--- a/src/TrayToolbar/SettingsForm.cs
+++ b/src/TrayToolbar/SettingsForm.cs
@@ -44,6 +44,7 @@ public partial class SettingsForm : Form
     public SettingsForm()
     {
         InitializeComponent();
+        LeftClickMenu.Closed += LeftClickMenu_Closed;
         SetupMenu();
         PopulateConfig();
         LoadResources(Configuration.Language);
@@ -351,6 +352,88 @@ public partial class SettingsForm : Form
         return icon;
     }
 
+    #region Tray icon loading spinner
+
+    private System.Windows.Forms.Timer? _spinnerTimer;
+    private int _spinnerFrame;
+    private readonly Dictionary<NotifyIcon, Icon> _spinnerBaseIcons = [];
+    private readonly Dictionary<NotifyIcon, Icon> _spinnerFrameIcons = [];
+
+    /// <summary>
+    /// Animates a spinner overlay on every tray icon whose menu is loading so it is
+    /// clear the icon is not ready to be clicked yet
+    /// </summary>
+    private void StartTrayIconSpinner()
+    {
+        if (InvokeRequired)
+        {
+            BeginInvoke(StartTrayIconSpinner);
+            return;
+        }
+        if (_spinnerTimer == null)
+        {
+            _spinnerTimer = new System.Windows.Forms.Timer(components) { Interval = 100 };
+            _spinnerTimer.Tick += SpinnerTimer_Tick;
+        }
+        _spinnerTimer.Start();
+    }
+
+    private void SpinnerTimer_Tick(object? sender, EventArgs e)
+    {
+        _spinnerFrame = (_spinnerFrame + 1) % SpinnerIconRenderer.FrameCount;
+        var anyLoading = false;
+        foreach (var trayIcon in TrayIcons)
+        {
+            var loading = trayIcon.Tag is FolderConfig folder
+                && MenuItems.TryGetValue(folder, out var menu)
+                && menu.NeedsRefresh;
+            if (loading && trayIcon.Icon != null)
+            {
+                anyLoading = true;
+                if (!_spinnerBaseIcons.ContainsKey(trayIcon))
+                {
+                    _spinnerBaseIcons[trayIcon] = trayIcon.Icon;
+                }
+                var frame = SpinnerIconRenderer.RenderFrame(_spinnerBaseIcons[trayIcon], _spinnerFrame);
+                trayIcon.Icon = frame;
+                if (_spinnerFrameIcons.TryGetValue(trayIcon, out var previousFrame))
+                {
+                    previousFrame.Dispose();
+                }
+                _spinnerFrameIcons[trayIcon] = frame;
+            }
+            else
+            {
+                RestoreTrayIcon(trayIcon);
+            }
+        }
+        // clean up icons that were replaced while spinning (e.g. settings were saved)
+        foreach (var stale in _spinnerBaseIcons.Keys.Where(i => !TrayIcons.Contains(i)).ToArray())
+        {
+            RestoreTrayIcon(stale);
+        }
+        if (!anyLoading)
+        {
+            _spinnerTimer!.Stop();
+        }
+    }
+
+    private void RestoreTrayIcon(NotifyIcon trayIcon)
+    {
+        if (_spinnerBaseIcons.TryGetValue(trayIcon, out var baseIcon))
+        {
+            trayIcon.Icon = baseIcon;
+            _spinnerBaseIcons.Remove(trayIcon);
+        }
+        if (_spinnerFrameIcons.TryGetValue(trayIcon, out var frameIcon))
+        {
+            frameIcon.Dispose();
+            _spinnerFrameIcons.Remove(trayIcon);
+        }
+    }
+
+    #endregion
+
     readonly ConcurrentDictionary<FolderConfig, CancellationTokenSource> refreshCancellation = [];
     private void RefreshMenu(FolderConfig folder)
     {
@@ -361,6 +444,7 @@ public partial class SettingsForm : Form
         if (MenuItems.TryGetValue(folder, out var menu))
         {
             menu.NeedsRefresh = true;
+            StartTrayIconSpinner();
             var cancellation = new CancellationTokenSource();
             refreshCancellation[folder] = cancellation;
             Task.Run(() =>
@@ -444,9 +528,36 @@ public partial class SettingsForm : Form
         }
         else
         {
+            if (MenuItems.TryGetValue(folder, out var menu) && menu.NeedsRefresh)
+            {
+                // The menu is still loading; pop it up automatically once it is
+                // ready instead of ignoring the click
+                _pendingTrayIconClick = trayIcon;
+                _pendingTrayIconClickTime = DateTime.UtcNow;
+                return;
+            }
+            _pendingTrayIconClick = null;
             if (!ShowLeftClickMenu(trayIcon, folder)) return;
         }
         trayIcon.ShowContextMenu();
+    }
+
+    private NotifyIcon? _pendingTrayIconClick;
+    private DateTime _pendingTrayIconClickTime;
+    private static readonly TimeSpan PendingTrayIconClickTimeout = TimeSpan.FromSeconds(10);
+
+    private void ShowPendingTrayIconClick(MenuItemCollection menu)
+    {
+        var trayIcon = _pendingTrayIconClick;
+        if (trayIcon?.Tag is not FolderConfig folder) return;
+        _pendingTrayIconClick = null;
+        if (DateTime.UtcNow - _pendingTrayIconClickTime > PendingTrayIconClickTimeout) return;
+        if (MenuItems.TryGetValue(folder, out var pendingMenu)
+            && pendingMenu == menu
+            && ShowLeftClickMenu(trayIcon, folder))
+        {
+            trayIcon.ShowContextMenu();
+        }
     }
 
     private bool ShowLeftClickMenu(NotifyIcon trayIcon, FolderConfig folder)
@@ -498,14 +609,43 @@ public partial class SettingsForm : Form
         }
     }
 
+    private readonly List<ToolStripDropDown> _suspendedDropDowns = [];
+
     private void LeftClickMenuEntry_MouseDown(object? sender, MouseEventArgs e)
     {
         RightMouseClicked = e.Button == MouseButtons.Right;
         if (RightMouseClicked && sender is ToolStripMenuItem menu)
         {
-            menu.DropDown.SetAutoClose(false);
+            RestoreSuspendedDropDowns(close: false);
+            _suspendedDropDowns.AddRange(menu.DropDown.SetAutoClose(false));
         }
         LeftClickMenu.AutoClose = !RightMouseClicked;
+    }
+
+    /// <summary>
+    /// Re-enables AutoClose on every dropdown that was suspended for a right-click, no matter
+    /// which menu item ends up receiving the click; a left-opening submenu can overlap its
+    /// parent so mouse-down and click may land on different items, which used to leave the
+    /// deepest submenu stuck open
+    /// </summary>
+    private void RestoreSuspendedDropDowns(bool close)
+    {
+        if (_suspendedDropDowns.Count == 0) return;
+        var suspended = _suspendedDropDowns.ToArray();
+        _suspendedDropDowns.Clear();
+        foreach (var dropDown in suspended)
+        {
+            dropDown.AutoClose = true;
+            if (close && dropDown.Visible)
+            {
+                dropDown.Close();
+            }
+        }
+    }
+
+    private void LeftClickMenu_Closed(object? sender, ToolStripDropDownClosedEventArgs e)
+    {
+        RestoreSuspendedDropDowns(close: true);
     }
 
     private void SetupLeftClickMenu(MenuItemCollection menu)
@@ -521,6 +661,7 @@ public partial class SettingsForm : Form
         LeftClickMenu.Items.AddRange(menu.ToArray());
 #pragma warning restore IDE0305
         menu.NeedsRefresh = false;
+        ShowPendingTrayIconClick(menu);
     }
 
     private IEnumerable<string> EnumerateFiles(string path, bool recursive)
@@ -581,6 +722,7 @@ public partial class SettingsForm : Form
     {
         LeftClickMenu.Hide();
         RightClickMenu.Hide();
+        RestoreSuspendedDropDowns(close: true);
     }
 
     private void RightClickMenu_ItemClicked(object sender, ToolStripItemClickedEventArgs e)
@@ -615,10 +757,8 @@ public partial class SettingsForm : Form
             {
                 ShowContextMenu(filename);
                 LeftClickMenu.AutoClose = true;
-                if (sender is ToolStripMenuItem menu)
-                {
-                    menu.DropDown.SetAutoClose(true);
-                }
+                RestoreSuspendedDropDowns(close: false);
+                RightMouseClicked = false;
             }
             else if (e.ClickedItem.AccessibleRole != AccessibleRole.MenuPopup)
             {
@@ -627,6 +767,7 @@ public partial class SettingsForm : Form
                     Program.Launch(filename);
                 }
                 catch { }
+                LaunchLogger.Log(Configuration, e.ClickedItem.Name.Or(Path.GetFileName(filename)) ?? "", filename);
                 LeftClickMenu.Close(ToolStripDropDownCloseReason.ItemClicked);
                 if (Visible)
                 {

--- a/src/TrayToolbar/TrayToolbar.csproj
+++ b/src/TrayToolbar/TrayToolbar.csproj
@@ -9,7 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>TrayToolbar.Program</StartupObject>
     <ApplicationIcon>Resources\TrayIcon.ico</ApplicationIcon>
-    <Version>1.8.2</Version>
+    <Version>1.8.3</Version>
     <Title>TrayToolbar</Title>
     <Copyright>© Brontech, LLC</Copyright>
     <PackageProjectUrl>https://github.com/brondavies/TrayToolbar</PackageProjectUrl>


### PR DESCRIPTION
## Summary

- Fixes #78 — folder-link cycles no longer hang menu load; the expansion chain is tracked and cyclic links render as regular items
- Fixes #82 — spinner overlay animates on the tray icon while its menu loads; a click during loading opens the menu once ready
- Fixes #86 — every dropdown suspended for a right-click is restored regardless of which item receives the click, so left-opening submenus can't get stuck open
- Fixes #100 — advertised (MSI/Darwin) shortcuts are shell-executed as the `.lnk` instead of launching the stub target they report
- Closes #85 — optional config-only launch logging: `csv` (default), `tsv`, `jsonl`, `syslog`, `cef`; ISO-8601 timestamps; off by default
- Chore: CodeQL action v3 → v4

## Validation

- [x] `dotnet test .\TrayToolbar.sln` from `src\` — 58 passed (13 new)
- [x] `dotnet format .\TrayToolbar.sln` from `src\`
- [x] `dotnet build .\TrayToolbar.sln` from `src\`
- [ ] `./build.ps1` — no packaging, update, or release asset changes
- [ ] Manual Windows verification of spinner and submenu behavior recommended

## Behavior notes

- User-visible changes: loading spinner on tray icons; cyclic folder links show as plain items; advertised shortcuts launch; submenus no longer get stuck open
- Configuration changes: new `LaunchLogEnabled` (default off), `LaunchLogFile`, `LaunchLogFormat`
- Update, launch-policy, or trust-boundary changes: none

## Documentation and release hygiene

- [x] Updated `CHANGELOG.md`
- [ ] `docs/release-notes.md` — defer to release
- [ ] `docs/update-security.md` / `SECURITY.md` — no trust-boundary change
- [x] Updated `docs/developer-guide.md` (launch logging schema rows + section)
