### PR TITLE
Finish 1.8.3 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,7 +122,8 @@ For narrative release summaries, packaging notes, and upgrade context that is ea
 
 - None.
 
-[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.2...HEAD
+[Unreleased]: https://github.com/brondavies/TrayToolbar/compare/v1.8.3...HEAD
+[1.8.3]: https://github.com/brondavies/TrayToolbar/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/brondavies/TrayToolbar/compare/v1.8.1...v1.8.2
 [1.8.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.1...v1.8.1
 [1.7.1]: https://github.com/brondavies/TrayToolbar/compare/v1.7.0...v1.7.1

--- a/src/TrayToolbar/app.manifest
+++ b/src/TrayToolbar/app.manifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.8.2.0" name="TrayToolbar"/>
+  <assemblyIdentity version="1.8.3.0" name="TrayToolbar"/>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
       <!-- Windows 10 -->


### PR DESCRIPTION
Bumps app.manifest assemblyIdentity to 1.8.3.0 and updates the CHANGELOG compare links, matching what create-release.ps1 would have done.